### PR TITLE
refactor: Remove unused exported functions to improve coverage

### DIFF
--- a/internal/types.go
+++ b/internal/types.go
@@ -1,11 +1,8 @@
 package internal
 
 import (
-	"go/ast"
 	"go/types"
-	"strings"
 
-	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/ssa"
 )
 
@@ -119,51 +116,6 @@ func unwrapPointer(t types.Type) types.Type {
 	return t
 }
 
-// =============================================================================
-// Generic Type Utilities
-// =============================================================================
-
-// ContextCarrier represents a type that can carry context.
-// Format: "pkg/path.TypeName" (e.g., "github.com/labstack/echo/v4.Context").
-type ContextCarrier struct {
-	PkgPath  string
-	TypeName string
-}
-
-// ParseContextCarriers parses a comma-separated list of context carriers.
-func ParseContextCarriers(s string) []ContextCarrier {
-	if s == "" {
-		return nil
-	}
-	parts := strings.Split(s, ",")
-	carriers := make([]ContextCarrier, 0, len(parts))
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-		lastDot := strings.LastIndex(part, ".")
-		if lastDot == -1 {
-			continue // Invalid format
-		}
-		carriers = append(carriers, ContextCarrier{
-			PkgPath:  part[:lastDot],
-			TypeName: part[lastDot+1:],
-		})
-	}
-	return carriers
-}
-
-// IsNamedType checks if the expression has the given named type.
-// It handles pointer types automatically.
-func IsNamedType(pass *analysis.Pass, expr ast.Expr, pkgPath, typeName string) bool {
-	tv, ok := pass.TypesInfo.Types[expr]
-	if !ok {
-		return false
-	}
-	return isNamedTypeFromType(tv.Type, pkgPath, typeName)
-}
-
 // isNamedTypeFromType checks if the type matches the given package path and type name.
 func isNamedTypeFromType(t types.Type, pkgPath, typeName string) bool {
 	t = unwrapPointer(t)
@@ -179,35 +131,4 @@ func isNamedTypeFromType(t types.Type, pkgPath, typeName string) bool {
 	}
 
 	return obj.Pkg().Path() == pkgPath && obj.Name() == typeName
-}
-
-// IsContextOrCarrierType checks if the type is context.Context or a configured carrier type.
-func IsContextOrCarrierType(t types.Type, carriers []ContextCarrier) bool {
-	if IsContextType(t) {
-		return true
-	}
-	for _, c := range carriers {
-		if isNamedTypeFromType(t, c.PkgPath, c.TypeName) {
-			return true
-		}
-	}
-	return false
-}
-
-// HasContextOrCarrierParam checks if the function type has a context.Context
-// or a context carrier parameter.
-func HasContextOrCarrierParam(pass *analysis.Pass, fnType *ast.FuncType, carriers []ContextCarrier) bool {
-	if fnType == nil || fnType.Params == nil {
-		return false
-	}
-	for _, field := range fnType.Params.List {
-		tv, ok := pass.TypesInfo.Types[field.Type]
-		if !ok {
-			continue
-		}
-		if IsContextOrCarrierType(tv.Type, carriers) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/types_test.go
+++ b/internal/types_test.go
@@ -5,77 +5,6 @@ import (
 	"testing"
 )
 
-func TestParseContextCarriers(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected []ContextCarrier
-	}{
-		{
-			name:     "empty string",
-			input:    "",
-			expected: nil,
-		},
-		{
-			name:  "single carrier",
-			input: "github.com/labstack/echo/v4.Context",
-			expected: []ContextCarrier{
-				{PkgPath: "github.com/labstack/echo/v4", TypeName: "Context"},
-			},
-		},
-		{
-			name:  "multiple carriers",
-			input: "github.com/labstack/echo/v4.Context,github.com/gin-gonic/gin.Context",
-			expected: []ContextCarrier{
-				{PkgPath: "github.com/labstack/echo/v4", TypeName: "Context"},
-				{PkgPath: "github.com/gin-gonic/gin", TypeName: "Context"},
-			},
-		},
-		{
-			name:  "with spaces",
-			input: "  github.com/labstack/echo/v4.Context , github.com/gin-gonic/gin.Context  ",
-			expected: []ContextCarrier{
-				{PkgPath: "github.com/labstack/echo/v4", TypeName: "Context"},
-				{PkgPath: "github.com/gin-gonic/gin", TypeName: "Context"},
-			},
-		},
-		{
-			name:     "invalid format without dot",
-			input:    "invalidformat",
-			expected: []ContextCarrier{},
-		},
-		{
-			name:  "mixed valid and invalid",
-			input: "github.com/valid.Type,,invalid,github.com/another.Type",
-			expected: []ContextCarrier{
-				{PkgPath: "github.com/valid", TypeName: "Type"},
-				{PkgPath: "github.com/another", TypeName: "Type"},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := ParseContextCarriers(tt.input)
-			if len(result) != len(tt.expected) {
-				t.Errorf("ParseContextCarriers(%q) returned %d carriers, expected %d",
-					tt.input, len(result), len(tt.expected))
-				return
-			}
-			for i, carrier := range result {
-				if carrier.PkgPath != tt.expected[i].PkgPath {
-					t.Errorf("carrier[%d].PkgPath = %q, expected %q",
-						i, carrier.PkgPath, tt.expected[i].PkgPath)
-				}
-				if carrier.TypeName != tt.expected[i].TypeName {
-					t.Errorf("carrier[%d].TypeName = %q, expected %q",
-						i, carrier.TypeName, tt.expected[i].TypeName)
-				}
-			}
-		})
-	}
-}
-
 func TestIsTerminatorMethod(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -127,78 +56,6 @@ func TestIsLogLevelMethod(t *testing.T) {
 	}
 }
 
-func TestIsContextOrCarrierType(t *testing.T) {
-	// Create a mock context.Context type
-	contextPkg := types.NewPackage("context", "context")
-	contextTypeName := types.NewTypeName(0, contextPkg, "Context", nil)
-	contextInterface := types.NewInterfaceType(nil, nil)
-	contextInterface.Complete()
-	contextNamed := types.NewNamed(contextTypeName, contextInterface, nil)
-
-	// Create a mock carrier type (e.g., echo.Context)
-	echoPkg := types.NewPackage("github.com/labstack/echo/v4", "echo")
-	echoTypeName := types.NewTypeName(0, echoPkg, "Context", nil)
-	echoInterface := types.NewInterfaceType(nil, nil)
-	echoInterface.Complete()
-	echoNamed := types.NewNamed(echoTypeName, echoInterface, nil)
-
-	// Create a non-matching type
-	otherPkg := types.NewPackage("other/pkg", "pkg")
-	otherTypeName := types.NewTypeName(0, otherPkg, "Other", nil)
-	otherStruct := types.NewStruct(nil, nil)
-	otherNamed := types.NewNamed(otherTypeName, otherStruct, nil)
-
-	carriers := []ContextCarrier{
-		{PkgPath: "github.com/labstack/echo/v4", TypeName: "Context"},
-	}
-
-	tests := []struct {
-		name     string
-		typ      types.Type
-		carriers []ContextCarrier
-		expected bool
-	}{
-		{
-			name:     "context.Context",
-			typ:      contextNamed,
-			carriers: carriers,
-			expected: true,
-		},
-		{
-			name:     "echo.Context carrier",
-			typ:      echoNamed,
-			carriers: carriers,
-			expected: true,
-		},
-		{
-			name:     "non-matching type",
-			typ:      otherNamed,
-			carriers: carriers,
-			expected: false,
-		},
-		{
-			name:     "nil carriers",
-			typ:      otherNamed,
-			carriers: nil,
-			expected: false,
-		},
-		{
-			name:     "pointer to context.Context",
-			typ:      types.NewPointer(contextNamed),
-			carriers: carriers,
-			expected: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := IsContextOrCarrierType(tt.typ, tt.carriers); got != tt.expected {
-				t.Errorf("IsContextOrCarrierType() = %v, expected %v", got, tt.expected)
-			}
-		})
-	}
-}
-
 func TestUnwrapPointer(t *testing.T) {
 	// Create a basic type
 	basicType := types.Typ[types.Int]
@@ -227,6 +84,56 @@ func TestUnwrapPointer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := unwrapPointer(tt.typ); got != tt.expected {
 				t.Errorf("unwrapPointer() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsContextType(t *testing.T) {
+	// Create a mock context.Context type
+	contextPkg := types.NewPackage("context", "context")
+	contextTypeName := types.NewTypeName(0, contextPkg, "Context", nil)
+	contextInterface := types.NewInterfaceType(nil, nil)
+	contextInterface.Complete()
+	contextNamed := types.NewNamed(contextTypeName, contextInterface, nil)
+
+	// Create a non-matching type
+	otherPkg := types.NewPackage("other/pkg", "pkg")
+	otherTypeName := types.NewTypeName(0, otherPkg, "Other", nil)
+	otherStruct := types.NewStruct(nil, nil)
+	otherNamed := types.NewNamed(otherTypeName, otherStruct, nil)
+
+	tests := []struct {
+		name     string
+		typ      types.Type
+		expected bool
+	}{
+		{
+			name:     "context.Context",
+			typ:      contextNamed,
+			expected: true,
+		},
+		{
+			name:     "non-context type",
+			typ:      otherNamed,
+			expected: false,
+		},
+		{
+			name:     "pointer to context.Context",
+			typ:      types.NewPointer(contextNamed),
+			expected: true,
+		},
+		{
+			name:     "basic type",
+			typ:      types.Typ[types.Int],
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsContextType(tt.typ); got != tt.expected {
+				t.Errorf("IsContextType() = %v, expected %v", got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Remove unused `ContextCarrier` struct and `ParseContextCarriers` function
- Remove unused `IsNamedType` function
- Remove unused `IsContextOrCarrierType` function
- Remove unused `HasContextOrCarrierParam` function
- Update tests to reflect removed code

## Impact
- Test coverage improved: **87% → 90%**
- Reduced code complexity by removing 79 lines of unused code
- No breaking changes to actual functionality (removed code was never used)

## Test plan
- [x] All existing tests pass (`./test_all.sh`)
- [x] Coverage verified with `go test -coverprofile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)