### PR TITLE
docs: add pkg.go.dev links and improve documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**zerologlintctx** is a Go linter that enforces context propagation in zerolog logging chains. It detects cases where a `context.Context` is available in function parameters but not properly passed to zerolog chains via `.Ctx(ctx)`.
+**zerologlintctx** is a Go linter that enforces context propagation in [zerolog](https://pkg.go.dev/github.com/rs/zerolog) logging chains. It detects cases where a [`context.Context`](https://pkg.go.dev/context#Context) is available in function parameters but not properly passed to zerolog chains via [`.Ctx(ctx)`](https://pkg.go.dev/github.com/rs/zerolog#Event.Ctx).
 
 ### Supported Checker
 
@@ -37,8 +37,8 @@ zerologlintctx/
 
 ### Key Design Decisions
 
-1. **Type-safe analysis**: Uses `go/types` for accurate detection (not just name-based)
-2. **SSA for zerolog**: Uses SSA form to track Event values through assignments
+1. **Type-safe analysis**: Uses [`go/types`](https://pkg.go.dev/go/types) for accurate detection (not just name-based)
+2. **SSA for zerolog**: Uses [SSA](https://pkg.go.dev/golang.org/x/tools/go/ssa) form to track Event values through assignments
 3. **Zero false positives**: Prefer missing issues over false alarms
 4. **Strategy Pattern**: Uses Strategy Pattern for tracing Event/Logger/Context types
 5. **Flat internal structure**: Single `internal/` package for simplicity (single checker)
@@ -136,5 +136,7 @@ These are documented in test cases with `LIMITATION` comments.
 
 ## Related Projects
 
-- [goroutinectx](https://github.com/mpyw/goroutinectx) - Goroutine context propagation linter (sibling project)
-- [contextcheck](https://github.com/kkHAIKE/contextcheck) - Detects `context.Background()`/`context.TODO()` misuse
+- [goroutinectx](https://github.com/mpyw/goroutinectx) - Goroutine context propagation linter
+- [ctxweaver](https://github.com/mpyw/ctxweaver) - Code generator for context-aware instrumentation
+- [gormreuse](https://github.com/mpyw/gormreuse) - GORM instance reuse linter
+- [contextcheck](https://github.com/kkHAIKE/contextcheck) - Detects [`context.Background()`](https://pkg.go.dev/context#Background)/[`context.TODO()`](https://pkg.go.dev/context#TODO) misuse

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Go linter that checks zerolog logging chains for missing context propagation.
 
 ## Overview
 
-`zerologlintctx` detects cases where a `context.Context` is available in function parameters but not properly passed to zerolog logging chains via `.Ctx(ctx)`.
+`zerologlintctx` detects cases where a [`context.Context`](https://pkg.go.dev/context#Context) is available in function parameters but not properly passed to [zerolog](https://pkg.go.dev/github.com/rs/zerolog) logging chains via [`.Ctx(ctx)`](https://pkg.go.dev/github.com/rs/zerolog#Event.Ctx).
 
 ## Installation & Usage
 
@@ -59,9 +59,9 @@ zerologlintctx -test=false ./...
 
 ## What It Checks
 
-### zerolog
+### [zerolog](https://pkg.go.dev/github.com/rs/zerolog)
 
-Detects zerolog logging chains missing `.Ctx(ctx)`:
+Detects zerolog logging chains missing [`.Ctx(ctx)`](https://pkg.go.dev/github.com/rs/zerolog#Event.Ctx):
 
 ```go
 func handler(ctx context.Context, log zerolog.Logger) {
@@ -93,14 +93,21 @@ The comment can be on the same line or the line above.
 ## Design Principles
 
 1. **Zero false positives** - Prefer missing issues over false alarms
-2. **Type-safe analysis** - Uses `go/types` for accurate detection
-3. **SSA-based tracking** - Uses SSA form to track Event values through assignments and closures
+2. **Type-safe analysis** - Uses [`go/types`](https://pkg.go.dev/go/types) for accurate detection
+3. **SSA-based tracking** - Uses [SSA](https://pkg.go.dev/golang.org/x/tools/go/ssa) form to track Event values through assignments and closures
 4. **Nested function support** - Correctly tracks context through closures
+
+## Documentation
+
+- [CLAUDE.md](./CLAUDE.md) - AI assistant guidance for development
 
 ## Related Tools
 
+- [goroutinectx](https://github.com/mpyw/goroutinectx) - Goroutine context propagation linter
+- [ctxweaver](https://github.com/mpyw/ctxweaver) - Code generator for context-aware instrumentation
+- [gormreuse](https://github.com/mpyw/gormreuse) - GORM instance reuse linter
 - [zerologlint](https://github.com/ykadowak/zerologlint) - General zerolog linting rules
-- [contextcheck](https://github.com/kkHAIKE/contextcheck) - Detects `context.Background()`/`context.TODO()` usage and missing context parameters
+- [contextcheck](https://github.com/kkHAIKE/contextcheck) - Detects [`context.Background()`](https://pkg.go.dev/context#Background)/[`context.TODO()`](https://pkg.go.dev/context#TODO) usage and missing context parameters
 
 `zerologlintctx` is complementary to these tools:
 - `zerologlint` provides general zerolog best practices


### PR DESCRIPTION
## Summary

- Add pkg.go.dev links for context.Context, zerolog, and Event.Ctx
- Add pkg.go.dev links for go/types and SSA
- Add Documentation section with link to CLAUDE.md
- Add sibling projects to Related Tools section
- Update CLAUDE.md with pkg.go.dev links

## Changes

### README.md
- Add pkg.go.dev links for `context.Context`, `zerolog`, and `Event.Ctx`
- Add links for `go/types` and `SSA` in Design Principles
- Add Documentation section linking to CLAUDE.md
- Add sibling projects (goroutinectx, ctxweaver, gormreuse) to Related Tools

### CLAUDE.md
- Add pkg.go.dev links for zerolog, context.Context, Event.Ctx
- Add pkg.go.dev links for go/types and SSA
- Add sibling projects to Related Projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)