### PR TITLE
refactor: Apply design patterns to improve code maintainability

### DIFF
--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -296,6 +296,6 @@ func (c *checker) report(pos token.Pos) {
 
 // eventChainHasCtx traces an Event value to check if .Ctx() was called.
 func (c *checker) eventChainHasCtx(v ssa.Value) bool {
-	tracer := newTracers()
-	return c.traceValue(v, tracer, make(map[ssa.Value]bool))
+	registry := newTracerRegistry()
+	return c.traceValue(v, registry.EventTracer(), make(map[ssa.Value]bool))
 }

--- a/internal/types.go
+++ b/internal/types.go
@@ -35,28 +35,15 @@ const (
 // =============================================================================
 
 func isEvent(t types.Type) bool {
-	return isZerologType(t, eventType)
+	return isNamedType(t, zerologPkgPath, eventType)
 }
 
 func isContext(t types.Type) bool {
-	return isZerologType(t, contextType)
+	return isNamedType(t, zerologPkgPath, contextType)
 }
 
 func isLogger(t types.Type) bool {
-	return isZerologType(t, loggerType)
-}
-
-func isZerologType(t types.Type, typeName string) bool {
-	t = unwrapPointer(t)
-	named, ok := t.(*types.Named)
-	if !ok {
-		return false
-	}
-	obj := named.Obj()
-	if obj == nil || obj.Pkg() == nil {
-		return false
-	}
-	return obj.Pkg().Path() == zerologPkgPath && obj.Name() == typeName
+	return isNamedType(t, zerologPkgPath, loggerType)
 }
 
 // =============================================================================
@@ -150,8 +137,12 @@ func isDirectLoggingFunc(fn *ssa.Function) bool {
 
 // IsContextType checks if the type is context.Context.
 func IsContextType(t types.Type) bool {
-	return isNamedTypeFromType(t, contextPkgPath, "Context")
+	return isNamedType(t, contextPkgPath, "Context")
 }
+
+// =============================================================================
+// Type Utilities
+// =============================================================================
 
 // unwrapPointer returns the element type if t is a pointer, otherwise returns t.
 func unwrapPointer(t types.Type) types.Type {
@@ -161,8 +152,9 @@ func unwrapPointer(t types.Type) types.Type {
 	return t
 }
 
-// isNamedTypeFromType checks if the type matches the given package path and type name.
-func isNamedTypeFromType(t types.Type, pkgPath, typeName string) bool {
+// isNamedType checks if the type matches the given package path and type name.
+// Handles pointer types transparently.
+func isNamedType(t types.Type, pkgPath, typeName string) bool {
 	t = unwrapPointer(t)
 
 	named, ok := t.(*types.Named)


### PR DESCRIPTION
## Summary

- **Unwrapper Pattern**: Extract `unwrapInner()` to unify SSA wrapper type handling, reducing `traceCommon` switch from 11 cases to 4 special cases
- **Validated State Pattern**: Replace `hasContext` 3-value tuple `(bool, tracer, ssa.Value)` with explicit `traceResult` type using `found()`, `delegateTo()`, `continueTracing()` constructors
- **Type Utility Consolidation**: Unify `isZerologType` and `isNamedTypeFromType` into single `isNamedType` function
- **Consistency Improvement**: Refactor `edgeLeadsToImpl` to reuse `unwrapInner` for consistent SSA value handling
- **Registry Pattern**: Introduce `tracerRegistry` to encapsulate circular tracer references

## Test plan

- [x] All existing tests pass (`./test_all.sh`)
- [x] No changes to external API
- [x] Linter runs successfully on itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)