### PR TITLE
fix!: Rename package from `analyzer` to `zerologlintctx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ go run github.com/mpyw/zerologlintctx/cmd/zerologlintctx@latest ./...
 ```
 
 > [!CAUTION]
-> To prevent supply chain attacks, pin to a specific version tag instead of `@latest` in CI/CD pipelines (e.g., `@v0.6.1`).
+> To prevent supply chain attacks, pin to a specific version tag instead of `@latest` in CI/CD pipelines (e.g., `@v0.7.0`).
 
 ## Flags
 

--- a/analyzer.go
+++ b/analyzer.go
@@ -1,6 +1,6 @@
-// Package analyzer provides a go/analysis based analyzer for detecting
+// Package zerologlintctx provides a go/analysis based analyzer for detecting
 // missing context propagation in zerolog logging chains.
-package analyzer
+package zerologlintctx
 
 import (
 	"errors"

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -1,20 +1,20 @@
-package analyzer_test
+package zerologlintctx_test
 
 import (
 	"testing"
 
 	"golang.org/x/tools/go/analysis/analysistest"
 
-	analyzer "github.com/mpyw/zerologlintctx"
+	"github.com/mpyw/zerologlintctx"
 )
 
 func TestZerolog(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, analyzer.Analyzer, "zerolog")
+	analysistest.Run(t, testdata, zerologlintctx.Analyzer, "zerolog")
 }
 
 func TestFileFilter(t *testing.T) {
 	testdata := analysistest.TestData()
 	// Tests that generated files are skipped
-	analysistest.Run(t, testdata, analyzer.Analyzer, "filefilter")
+	analysistest.Run(t, testdata, zerologlintctx.Analyzer, "filefilter")
 }

--- a/cmd/zerologlintctx/main.go
+++ b/cmd/zerologlintctx/main.go
@@ -8,5 +8,5 @@ import (
 )
 
 func main() {
-	singlechecker.Main(analyzer.Analyzer)
+	singlechecker.Main(zerologlintctx.Analyzer)
 }

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,5 @@ require (
 // Retract all previous versions due to critical bugs:
 // - v0.0.1 to v0.3.0: -test flag conflicted with singlechecker's built-in flag
 // - v0.4.0: False positives for log.Ctx(ctx) patterns, missing direct logging detection
-retract [v0.0.1, v0.4.0]
+// - v0.5.0 to v0.6.1: Package name was `analyzer` instead of `zerologlintctx`
+retract [v0.0.1, v0.6.1]


### PR DESCRIPTION
## Summary

- Rename package from `analyzer` to `zerologlintctx` to match the module path
- Retract all previous versions (v0.0.1 to v0.6.1)
- Update README version reference to v0.7.0

## Breaking Change

```go
// Before
import analyzer "github.com/mpyw/zerologlintctx"
analyzer.Analyzer

// After
import "github.com/mpyw/zerologlintctx"
zerologlintctx.Analyzer
```

## Test plan

- [x] `./test_all.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)