### PR TITLE
fix: Handle self-referential stores in pointer-based loops

### DIFF
--- a/testdata/src/zerolog/evil_ssa.go
+++ b/testdata/src/zerolog/evil_ssa.go
@@ -16,7 +16,6 @@
 //   - Embedded struct: `h.Msg()` where h embeds *Event
 //   - Closure-modified capture: Closure writes to outer var
 //   - IIFE unreachable return: SSA doesn't eliminate unreachable code in IIFE
-//   - Pointer-based loop: Cyclic Store dependencies through pointer in loop
 package zerolog
 
 import (
@@ -1179,16 +1178,16 @@ func badPointerBasedLoop(ctx context.Context, logger zerolog.Logger) {
 	(*ptr).Msg("pointer loop") // want `zerolog call chain missing .Ctx\(ctx\)`
 }
 
-// LIMITATION (false positive): Pointer-based loop with ctx
-// When event is modified through pointer in a loop, the analyzer may report
-// false positives due to cyclic Store dependencies.
-func limitationPointerBasedLoopWithCtx(ctx context.Context, logger zerolog.Logger) {
+// Test case: Pointer-based loop with ctx - properly traced
+// Self-referential stores (*ptr = (*ptr).Str(...)) are skipped as they
+// just transform the existing value without changing ctx status.
+func goodPointerBasedLoopWithCtx(ctx context.Context, logger zerolog.Logger) {
 	e := logger.Info().Ctx(ctx)
 	ptr := &e
 	for i := 0; i < 3; i++ {
 		*ptr = (*ptr).Str("key", "val")
 	}
-	(*ptr).Msg("pointer loop with ctx") // want `zerolog call chain missing .Ctx\(ctx\)`
+	(*ptr).Msg("pointer loop with ctx") // OK - ctx set in initial store
 }
 
 // ===== POINTER WITH CONDITIONAL STORE =====


### PR DESCRIPTION
## Summary
- Fix false positive in pointer-based loop patterns where event is modified through pointer (e.g., `*ptr = (*ptr).Str(...)`)
- Add `valueLoadsFrom()` helper to detect self-referential stores
- Skip self-referential stores during tracing since they just transform the existing value

Fixes #19

## Test plan
- [x] Existing tests pass
- [x] Changed `limitationPointerBasedLoopWithCtx` test to `goodPointerBasedLoopWithCtx` (no longer reports)
- [x] Conditional store tests still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)