### PR TITLE
ci: track the go directive instead of a hardcoded Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,18 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ['1.27']
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Set up Go ${{ matrix.go-version }}
+      - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: ${{ matrix.go-version }}
+          # Track the go directive in go.mod. setup-go sets GOTOOLCHAIN=local,
+          # so a hardcoded version fails outright once a dependency bump raises
+          # the directive above it, instead of picking up a newer toolchain.
+          go-version-file: go.mod
 
       - name: Run tests with coverage
         run: go test -v -race -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... ./...
@@ -33,7 +33,7 @@ jobs:
         with:
           files: ./coverage.txt
           flags: unittests
-          name: codecov-go${{ matrix.go-version }}
+          name: codecov
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
@@ -49,12 +49,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.27'
+          go-version-file: go.mod
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          # Needs a binary built with Go 1.27 (v2.13.0+): golangci-lint refuses
-          # to load a module whose go directive is newer than its own build.
+          # golangci-lint refuses to load a module whose go directive is newer
+          # than the Go it was built with, so this pin has to move whenever the
+          # directive in go.mod does. v2.13.0+ is built with Go 1.27.
           version: v2.13.1
           args: --timeout=5m


### PR DESCRIPTION
Fixes the failure mode that broke dependabot #29.

## What happened

`actions/setup-go` sets **`GOTOOLCHAIN=local`**. With a hardcoded `go-version`, a dependency bump that raises the `go` directive above it fails outright instead of picking up a newer toolchain:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

That is exactly what happened in #29 — bumping x/tools to v0.48.0 raised the directive to `1.25.0`, the `Test (1.24)` entry died in 8s, took the `Lint` job with it (also pinned to Go 1.24), and fail-fast cancelled `Test (1.25)` before it ever ran. The bump itself was fine; only the toolchain provisioning was wrong.

## Change

`go-version-file: go.mod` in both jobs, so the toolchain follows the directive and future dependency bumps that raise it stay green. The matrix held a single version (`['1.27']`) and is dropped with it; the Codecov `name` loses its now-meaningless matrix suffix.

## Residual coupling worth knowing about

The golangci-lint pin still has to move when the directive does — a binary built with an older Go refuses to load the module, which is why `v2.13.1` is pinned today. Dependabot's `github-actions` ecosystem bumps `uses:` refs but not `with: version:` inputs, so this one is manual. The comment now says so.

Two ways to remove that coupling if it becomes annoying:
- drop `version:` entirely — the action resolves an empty value to `latest`, which always tracks the newest Go, at the cost of an unpinned tool;
- `install-mode: goinstall` with the pin kept, so golangci-lint is compiled with the runner's Go — robust and still pinned, but adds a few minutes per run.

Neither is applied here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)